### PR TITLE
[FIX] Login button won't click

### DIFF
--- a/ppmi_downloader/ppmi_downloader.py
+++ b/ppmi_downloader/ppmi_downloader.py
@@ -380,6 +380,7 @@ class HTMLHelper:
     def login(self, email, password):
         self.driver.get("https://ida.loni.usc.edu/login.jsp?project=PPMI")
         self.click_button("ida-cookie-policy-accept", BY=By.CLASS_NAME)
+        time.sleep(3)
         self.click_button("ida-user-menu-icon", BY=By.CLASS_NAME)
 
         self.enter_data("userEmail", email, BY=By.NAME)


### PR DESCRIPTION
The following hotfix bypasses an issue with the login page. In the current state, the scrapper does not login to an account since the login button is not immediately available after accepting to cookie policy. The fix simply adds a timeout in order to wait for the button to become available.