### PR TITLE
[FIX] file path for GitHub action.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+        
       - name: Setup Python
         uses: actions/setup-python@v4.2.0
 

--- a/ppmi_downloader/tests/test_ppmi_downloader.py
+++ b/ppmi_downloader/tests/test_ppmi_downloader.py
@@ -13,7 +13,9 @@ ppmi = PPMIDownloader()
 @pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_download_metadata():
     """Download 3 random files from PPMI."""
-    with open(Path(__file__).parents[1].joinpath("file_id.json").resolve()) as fin:
+    with open(
+        Path(os.getcwd()).joinpath("ppmi_downloader", "file_id.json").resolve()
+    ) as fin:
         file_id = json.load(fin)
     filenames = file_id.keys()
     ppmi.download_metadata(random.sample(filenames, min(3, len(filenames))))


### PR DESCRIPTION
Using the current working directory instead of `Path(__file__)` should fix the GitHub action for testing the scraper.
 