### PR TITLE
"ALL" button id update

### DIFF
--- a/ppmi_downloader/ppmi_navigator.py
+++ b/ppmi_downloader/ppmi_navigator.py
@@ -574,7 +574,7 @@ class PPMINavigator(HTMLHelper):
         '''
         studydata_url = 'https://ida.loni.usc.edu/pages/access/studyData.jsp'
         while self.driver.current_url != studydata_url:
-            self.click_button("ygtvlabelel71", BY=By.ID, debug_name='ALL')
+            self.click_button("ygtvlabelel74", BY=By.ID, debug_name='ALL')
 
     def Download_ImageCollections(self) -> None:
         r'''Action to click on "Image Collections" in "Download"


### PR DESCRIPTION
This should fix the currently failing tests.

@yohanchatelain, the function below seems to be clicking on button "ALL" without requiring its id:

https://github.com/LivingPark-MRI/ppmi-scraper/blob/24dc873ca9501165936b5aac3537e33185e1cfa6/ppmi_downloader/ppmi_downloader.py#L278

Is there a way we could use the same approach in function `Download_StudyData_ALL` too?