### PR TITLE
[FIX] download of nifti images

### DIFF
--- a/ppmi_downloader/__init__.py
+++ b/ppmi_downloader/__init__.py
@@ -1,1 +1,5 @@
-from .ppmi_downloader import PPMIDownloader, PPMINiftiFileFinder
+from .ppmi_downloader import (
+    fileMatchingError,
+    PPMIDownloader,
+    PPMINiftiFileFinder,
+)


### PR DESCRIPTION
The current heuristic to find nifti images fails for some visits.

This PR fixes this issue. When errors occur, an exception is raised instead of doing an assertion.