### PR TITLE
[FIX] broken link to "ALL" buttoni in metadata page.

### DIFF
--- a/ppmi_downloader/ppmi_downloader.py
+++ b/ppmi_downloader/ppmi_downloader.py
@@ -294,7 +294,10 @@ class PPMIDownloader:
         and their corresponding checkbox id
         """
         self.init_and_log()
-        self.html.click_button_chain(["Download", "Study Data", "ALL"])
+        self.html.click_button_chain(["Download", "Study Data"])
+        self.html.click_button(
+            '//*[@id="categoryMenuTree"]//*[@class="ida-studyData-category"][text()="ALL"]'
+        )
         soup = BeautifulSoup(self.driver.page_source, features="lxml")
         study_name_to_checkbox = self.crawl_checkboxes_id(soup)
 
@@ -648,7 +651,10 @@ class PPMIDownloader:
 
         # navigate to metadata page
         self.driver.get(ppmi_home_webpage)
-        self.html.click_button_chain(["Download", "Study Data", "ALL"])
+        self.html.click_button_chain(["Download", "Study Data"])
+        self.html.click_button(
+            '//*[@id="categoryMenuTree"]//*[@class="ida-studyData-category"][text()="ALL"]',
+        )
 
         # select file and download
         for file_name in file_ids:

--- a/ppmi_downloader/ppmi_downloader.py
+++ b/ppmi_downloader/ppmi_downloader.py
@@ -294,10 +294,7 @@ class PPMIDownloader:
         and their corresponding checkbox id
         """
         self.init_and_log()
-        self.html.click_button_chain(["Download", "Study Data"])
-        self.html.click_button(
-            '//*[@id="categoryMenuTree"]//*[@class="ida-studyData-category"][text()="ALL"]'
-        )
+        self.html.click_button_chain(["Download", "Study Data", "ALL"])
         soup = BeautifulSoup(self.driver.page_source, features="lxml")
         study_name_to_checkbox = self.crawl_checkboxes_id(soup)
 
@@ -651,10 +648,7 @@ class PPMIDownloader:
 
         # navigate to metadata page
         self.driver.get(ppmi_home_webpage)
-        self.html.click_button_chain(["Download", "Study Data"])
-        self.html.click_button(
-            '//*[@id="categoryMenuTree"]//*[@class="ida-studyData-category"][text()="ALL"]',
-        )
+        self.html.click_button_chain(["Download", "Study Data", "ALL"])
 
         # select file and download
         for file_name in file_ids:

--- a/ppmi_downloader/ppmi_navigator.py
+++ b/ppmi_downloader/ppmi_navigator.py
@@ -668,9 +668,11 @@ class PPMINavigator(HTMLHelper):
         while not self.driver.current_url == studydata_url:
             # Need to click on ALL tab first to be able to see all checkboxes
             # See screenshots_errors/Screenshot_error_ALL_06-12-2023.jpg
-            self.click_button("ygtvlabelel77", BY=By.ID, debug_name="ALL tab")
-        while not self.driver.current_url.startswith(studydata_url):
-            self.click_button("sCatChkBox_312", BY=By.ID, debug_name="ALL checkbox")
+
+            self.click_button(
+                '//*[@id="categoryMenuTree"]//*[@class="ida-studyData-category"][text()="ALL"]',
+                debug_name="ALL tab",
+            )
 
     def Download_ImageCollections(self) -> None:
         r"""Action to click on "Image Collections" in "Download"


### PR DESCRIPTION
PPMI portal changed the ID for the `ALL` button. This PR changes the code to use XPATH and find the button relying on the text instead. This should be more resilient to change on the portal.